### PR TITLE
Added parsing of missing values and never clause.

### DIFF
--- a/src/mltk/core/Instance.java
+++ b/src/mltk/core/Instance.java
@@ -288,9 +288,15 @@ public class Instance implements Copyable<Instance> {
 			}
 		} else {
 			double[] values = getValues();
-			sb.append(values[0]);
+			if (Double.isNaN(values[0])) 
+				sb.append("?");
+			else	
+				sb.append(values[0]);
 			for (int i = 1; i < values.length; i++) {
-				sb.append("\t").append(values[i]);
+				if (Double.isNaN(values[i])) 
+					sb.append("\t?");
+				else	
+					sb.append("\t").append(values[i]);
 			}
 			if (!Double.isNaN(getTarget())) {
 				sb.append("\t").append(getTarget());

--- a/src/mltk/core/Instances.java
+++ b/src/mltk/core/Instances.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import mltk.core.io.AttrInfo;
 import mltk.util.Random;
 
 /**
@@ -48,6 +49,15 @@ public class Instances implements Iterable<Instance>, Copyable<Instances> {
 		this(attributes, targetAtt, 1000);
 	}
 
+	/**
+	 * Constructs a dataset from attributes and target attribute.
+	 * 
+	 * @param ainfo container for attributes and target attribute.
+	 */	
+	public Instances(AttrInfo ainfo) {
+		this(ainfo.attributes, ainfo.clsAttr);
+	}
+	
 	/**
 	 * Constructs a dataset from attributes and target attribute, with specified capacity.
 	 * 

--- a/src/mltk/core/io/AttributesReader.java
+++ b/src/mltk/core/io/AttributesReader.java
@@ -3,19 +3,21 @@ package mltk.core.io;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import mltk.core.Attribute;
 import mltk.core.BinnedAttribute;
 import mltk.core.NominalAttribute;
 import mltk.core.NumericalAttribute;
-import mltk.util.tuple.Pair;
+
 
 /**
- * Class for reading attributes. It only reads in a list of attributes from the attribute file.
+ * Class for reading attributes information. 
+ * It reads in a list of attributes, list of inactive attributes and a class attribute
+ *  from the attribute file.
  * 
- * @author Yin Lou
+ * @author Yin Lou, modified by Daria Sorokina
  * 
  */
 public class AttributesReader {
@@ -24,17 +26,39 @@ public class AttributesReader {
 	 * Reads attributes and class attribute from attribute file.
 	 * 
 	 * @param attFile the attribute file.
-	 * @return a pair of attributes and class attribute (null if no class attribute).
+	 * @return attribute information instance.
 	 * @throws IOException
 	 */
-	public static Pair<List<Attribute>, Attribute> read(String attFile) throws IOException {
-		BufferedReader br = new BufferedReader(new FileReader(attFile), 65535);
-		List<Attribute> attributes = new ArrayList<Attribute>();
-		Attribute clsAttr = null;
-		for (int i = 0;; i++) {
-			String line = br.readLine();
-			if (line == null) {
+	public static AttrInfo read(String attFile) throws IOException {
+		
+		Set<String> neverNames = new HashSet<String>();
+		AttrInfo ainfo = new AttrInfo();
+		
+		BufferedReader br1 = new BufferedReader(new FileReader(attFile), 65535);
+		String line = br1.readLine();		
+		while ((line != null) && (line.indexOf("contexts:") == -1)) {
+			line = br1.readLine();
+		}
+		if (line != null) {
+			line = br1.readLine();
+		}
+		while (line != null) {
+			neverNames.add(line.split(" ")[0]);
+			line = br1.readLine();
+		}
+		br1.close();
+		
+		BufferedReader br2 = new BufferedReader(new FileReader(attFile), 65535);
+		ainfo.clsAttr = null;
+		for (int i = 0, col = 0;; i++, col++) {
+			line = br2.readLine();
+			if ((line == null) || (line.indexOf("contexts:") != -1)) {
 				break;
+			}
+			String aname = line.split(": ")[0];
+			if(neverNames.contains(aname)) {
+				i--;
+				continue;
 			}
 			Attribute att = null;
 			if (line.indexOf("binned") != -1) {
@@ -44,17 +68,19 @@ public class AttributesReader {
 			} else {
 				att = NumericalAttribute.parse(line);
 			}
-			att.setIndex(i);
 			if (line.indexOf("(class)") != -1) {
-				clsAttr = att;
+				att.setIndex(col);
+				ainfo.clsAttr = att;
 				i--;
 			} else {
-				attributes.add(att);
+				att.setIndex(i);
+				ainfo.attributes.add(att);
+				ainfo.columns.add(col);
 			}
 		}
-		br.close();
+		br2.close();
 
-		return new Pair<List<Attribute>, Attribute>(attributes, clsAttr);
+		return ainfo;
 	}
 
 }

--- a/src/mltk/core/processor/Discretizer.java
+++ b/src/mltk/core/processor/Discretizer.java
@@ -374,7 +374,7 @@ public class Discretizer {
 				}
 			}
 		} else if (app.disAttPath != null) {
-			attributes = AttributesReader.read(app.disAttPath).v1;
+			attributes = AttributesReader.read(app.disAttPath).attributes;
 		} else {
 			parser.printUsage();
 			System.exit(1);


### PR DESCRIPTION
Hi Yin,
I figured out how to do a proper pull request - here it is.

I've added a few more modifications and it is safe to merge my changes now. By default, missing values are not accepted - if they are present, a message "missing values not allowed" shows up and the code proceeds to crash exactly as it would have done before. In order for missing values to be converted to NaNs, one needs to specifically call InstanceReader.read(...) with an additional flag argument set to true.

Never clause is simply parsed properly now - no side effects, doesn't depend on predictor type. Safe to merge. I haven't changed any code for the actual predictors, they all should work as before.

Let me know if you have any more concerns - I can do further tests or modifications if you want. Otherwise I would appreciate if you approve the pull request before introducing any new changes to mltk.