### PR TITLE
Set a fixed number of pairs for GA2M

### DIFF
--- a/src/mltk/predictor/gam/GA2MLearner.java
+++ b/src/mltk/predictor/gam/GA2MLearner.java
@@ -71,7 +71,7 @@ public class GA2MLearner extends HoldoutValidatedLearner {
 		double learningRate = 0.01;
 		
 		@Argument(name = "-p", description = "maximum number of pairs")
-		double numPairs = Integer.MAX_VALUE;
+		int numPairs = Integer.MAX_VALUE;
 
 	}
 
@@ -106,7 +106,7 @@ public class GA2MLearner extends HoldoutValidatedLearner {
 		CmdLineParser parser = new CmdLineParser(GA2MLearner.class, opts);
 		Task task = null;
 		Metric metric = null;
-		int numPairs = (int) opts.numPairs;
+
 		try {
 			parser.parse(args);
 			task = Task.get(opts.task);
@@ -124,6 +124,8 @@ public class GA2MLearner extends HoldoutValidatedLearner {
 
 		Instances trainSet = InstancesReader.read(opts.attPath, opts.trainPath);
 
+		int numPairs = (int) opts.numPairs;
+		System.out.println("Using only " + numPairs + " pairs");
 		List<IntPair> terms = new ArrayList<>();
 		BufferedReader br = new BufferedReader(new FileReader(opts.interactionsPath));
 		int npairs = 0;
@@ -142,6 +144,7 @@ public class GA2MLearner extends HoldoutValidatedLearner {
 		GAM gam = PredictorReader.read(opts.inputModelPath, GAM.class);
 
 		GA2MLearner learner = new GA2MLearner();
+		learner.setPairs(terms);
 		learner.setBaggingIters(opts.baggingIters);
 		learner.setGAM(gam);
 		learner.setMaxNumIters(opts.maxNumIters);

--- a/src/mltk/predictor/gam/GA2MLearner.java
+++ b/src/mltk/predictor/gam/GA2MLearner.java
@@ -1,6 +1,7 @@
 package mltk.predictor.gam;
 
 import java.io.BufferedReader;
+
 import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -68,6 +69,9 @@ public class GA2MLearner extends HoldoutValidatedLearner {
 
 		@Argument(name = "-l", description = "learning rate (default: 0.01)")
 		double learningRate = 0.01;
+		
+		@Argument(name = "-p", description = "maximum number of pairs")
+		double numPairs = Integer.MAX_VALUE;
 
 	}
 
@@ -89,6 +93,7 @@ public class GA2MLearner extends HoldoutValidatedLearner {
 	 * [-b]	bagging iterations (default: 100)
 	 * [-s]	seed of the random number generator (default: 0)
 	 * [-l]	learning rate (default: 0.01)
+	 * [-p] maximum number of pairs
 	 * </pre>
 	 * 
 	 * </p>
@@ -101,6 +106,7 @@ public class GA2MLearner extends HoldoutValidatedLearner {
 		CmdLineParser parser = new CmdLineParser(GA2MLearner.class, opts);
 		Task task = null;
 		Metric metric = null;
+		int numPairs = (int) opts.numPairs;
 		try {
 			parser.parse(args);
 			task = Task.get(opts.task);
@@ -120,7 +126,9 @@ public class GA2MLearner extends HoldoutValidatedLearner {
 
 		List<IntPair> terms = new ArrayList<>();
 		BufferedReader br = new BufferedReader(new FileReader(opts.interactionsPath));
-		for (;;) {
+		int npairs = 0;
+		while(npairs < numPairs) {
+			npairs ++;
 			String line = br.readLine();
 			if (line == null) {
 				break;


### PR DESCRIPTION
As discussed, I've added a new parameter '-p' to set the number of pairs we'd like to use (default is all of them). When reading the interactions file, we stop when we've reached the desired number of pairs.

This PR also fixes a bug: `setPairs` was missing in `main`.