### PR TITLE
Fixing broken GLM serialization/deserialization

### DIFF
--- a/src/mltk/predictor/glm/GLM.java
+++ b/src/mltk/predictor/glm/GLM.java
@@ -126,9 +126,15 @@ public class GLM implements ProbabilisticClassifier, Regressor {
 		return intercept[k];
 	}
 
+	/**
+	 * Please note that this is an internal method - to read a GLM please
+	 * use PredictorReader.read().
+	 * 
+	 * @param in The BufferedReader to read from
+	 * @throws Exception
+	 */
 	@Override
 	public void read(BufferedReader in) throws Exception {
-		in.readLine();
 		link = LinkFunction.get(in.readLine().split(": ")[1]);
         	in.readLine();
 		intercept = ArrayUtils.parseDoubleArray(in.readLine());


### PR DESCRIPTION
When attempting to write() and then read() a GLM instance, the following exception is thrown:

java.lang.IllegalArgumentException: Unknown link function: identityIntercept
	at mltk.predictor.LinkFunction.get(LinkFunction.java:28)
	at mltk.predictor.glm.GLM.read(GLM.java:132)

This PR corrects the format of the output of the write method and modifies the read method accordingly