### PR TITLE
Fixing RandomForest.read()

### DIFF
--- a/src/mltk/predictor/tree/ensemble/rf/RandomForest.java
+++ b/src/mltk/predictor/tree/ensemble/rf/RandomForest.java
@@ -37,6 +37,7 @@ public class RandomForest implements Regressor {
 
 	@Override
 	public void read(BufferedReader in) throws Exception {
+		in.readLine();
 		int capacity = Integer.parseInt(in.readLine().split(": ")[1]);
 		rtList = new RTreeList(capacity);
 		in.readLine();

--- a/src/mltk/predictor/tree/ensemble/rf/RandomForest.java
+++ b/src/mltk/predictor/tree/ensemble/rf/RandomForest.java
@@ -35,9 +35,15 @@ public class RandomForest implements Regressor {
 		rtList = new RTreeList(capacity);
 	}
 
+	/**
+	 * Please note that this is an internal method - to read a RandomForest
+	 * please use PredictorReader.read().
+	 * 
+	 * @param in
+	 * @throws Exception
+	 */
 	@Override
 	public void read(BufferedReader in) throws Exception {
-		in.readLine();
 		int capacity = Integer.parseInt(in.readLine().split(": ")[1]);
 		rtList = new RTreeList(capacity);
 		in.readLine();


### PR DESCRIPTION
This PR fixes the following exception, occuring on RandomForest.read()

Exception in thread "main" java.lang.NumberFormatException: For input string: "mltk.predictor.tree.ensemble.rf.RandomForest]"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:492)
	at java.lang.Integer.parseInt(Integer.java:527)
	at mltk.predictor.tree.ensemble.rf.RandomForest.read(RandomForest.java:40)